### PR TITLE
Fix dir for unpacking additional scripts

### DIFF
--- a/src/main/bash/pipeline.sh
+++ b/src/main/bash/pipeline.sh
@@ -596,8 +596,8 @@ if [[ "${ADDITIONAL_SCRIPTS_TARBALL_URL}" != "" ]]; then
 	"${CURL_BIN}" -u "${M2_SETTINGS_REPO_USERNAME}:${M2_SETTINGS_REPO_PASSWORD}" "${ADDITIONAL_SCRIPTS_TARBALL_URL}" -o "${destination}" --fail && success="true"
 	if [[ "${success}" == "true" ]]; then
 		echo "File downloaded successfully to [${destination}]!"
-		"${TAR_BIN}" -zxf "${destination}" -C "${__DIR}"
-		echo "Files unpacked successfully from [${destination}] to [${__DIR}]"
+		"${TAR_BIN}" -zxf "${destination}" -C "${__ROOT}"
+		echo "Files unpacked successfully from [${destination}] to [${__ROOT}]"
 	else
 		echo "Failed to download file!"
 	fi


### PR DESCRIPTION
When unpacking addicional custom script, the pipeline-k8s.sh custom is not found because the pipeline.sh is unpacking the custom file in /projectType -> ${__DIR}, but pipeline.sh source custom file look at ${__ROOT}
I have tested in ${__ROOT} and work.

14:53:18 File downloaded successfully to [/tmp/tmp.z649Ihxm4k/scripts.tar.gz]!
14:53:18 Files unpacked successfully from [/tmp/tmp.z649Ihxm4k/scripts.tar.gz] to [/var/jenkins_home/workspace/DanceSchool-Customer-pipeline-test-env-deploy/.git/tools/src/main/bash/projectType]
14:53:18 Custom script identifier is [custom]
14:53:18 Path to custom script for current step is [/var/jenkins_home/workspace/DanceSchool-Customer-pipeline-test-env-deploy/.git/tools/src/main/bash/custom/test_deploy.sh]
14:53:18 Path to custom script for PAAS is [/var/jenkins_home/workspace/DanceSchool-Customer-pipeline-test-env-deploy/.git/tools/src/main/bash/custom/pipeline-k8s.sh]
14:53:18 No /var/jenkins_home/workspace/DanceSchool-Customer-pipeline-test-env-deploy/.git/tools/src/main/bash/custom/test_deploy.sh found
14:53:18 No /var/jenkins_home/workspace/DanceSchool-Customer-pipeline-test-env-deploy/.git/tools/src/main/bash/custom/pipeline-k8s.sh found