### PR TITLE
URL Cleanup

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,4 +1,4 @@
-# EditorConfig is awesome: http://EditorConfig.org
+# EditorConfig is awesome: https://EditorConfig.org
 
 # top-most EditorConfig file
 root = true

--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@
 *.war
 *.ear
 
-# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
+# virtual machine crash logs, see https://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
 
 .gradle

--- a/docs-sources/src/main/asciidoc/FLOW.adoc
+++ b/docs-sources/src/main/asciidoc/FLOW.adoc
@@ -111,11 +111,11 @@ microservices. That way, the testing setup looks like the following image:
 image::{intro-root-docs}/stubbed_dependencies.png[title="We're testing microservices in isolation"]
 
 Such an approach to testing and deployment gives the following benefits
-(thanks to the usage of http://cloud.spring.io/spring-cloud-contract/spring-cloud-contract.html[Spring Cloud Contract]):
+(thanks to the usage of https://cloud.spring.io/spring-cloud-contract/spring-cloud-contract.html[Spring Cloud Contract]):
 
 * No need to deploy dependent services.
 * The stubs used for the tests run on a deployed microservice are the same as those used during integration tests.
-* Those stubs have been tested against the application that produces them (see http://cloud.spring.io/spring-cloud-contract/spring-cloud-contract.html[Spring Cloud Contract] for more information).
+* Those stubs have been tested against the application that produces them (see https://cloud.spring.io/spring-cloud-contract/spring-cloud-contract.html[Spring Cloud Contract] for more information).
 * We do not have many slow tests running on a deployed application, so the pipeline gets executed much faster.
 * We do not have to queue deployments. We test in isolation so that pipelines do not interfere with each other.
 * We do not have to spawn virtual machines each time for deployment purposes.

--- a/docs-sources/src/main/asciidoc/TECH.adoc
+++ b/docs-sources/src/main/asciidoc/TECH.adoc
@@ -26,7 +26,7 @@ In the `docs-source` folder, you can find the sources required to generate the d
 [[building-prerequisites]]
 === Prerequisites
 
-As prerequisites, you need to have http://www.shellcheck.net/[shellcheck],
+As prerequisites, you need to have https://www.shellcheck.net/[shellcheck],
 https://github.com/sstephenson/bats[bats], https://stedolan.github.io/jq/[jq]
 and https://rubyinstaller.org/downloads/[ruby] installed. If you use a Linux
 machine, `bats` and `shellcheck` are installed for you.

--- a/docs/BASH_SCRIPTS.html
+++ b/docs/BASH_SCRIPTS.html
@@ -8,7 +8,7 @@
 <title>SCRIPTS</title>
 <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700">
 <style>
-/* Asciidoctor default stylesheet | MIT License | http://asciidoctor.org */
+/* Asciidoctor default stylesheet | MIT License | https://asciidoctor.org */
 /* Uncomment @import statement below to use as custom stylesheet */
 /*@import "https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700";*/
 article,aside,details,figcaption,figure,footer,header,hgroup,main,nav,section,summary{display:block}

--- a/docs/CUSTOMIZATION.html
+++ b/docs/CUSTOMIZATION.html
@@ -8,7 +8,7 @@
 <title>Customizing the Project</title>
 <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700">
 <style>
-/* Asciidoctor default stylesheet | MIT License | http://asciidoctor.org */
+/* Asciidoctor default stylesheet | MIT License | https://asciidoctor.org */
 /* Uncomment @import statement below to use as custom stylesheet */
 /*@import "https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700";*/
 article,aside,details,figcaption,figure,footer,header,hgroup,main,nav,section,summary{display:block}

--- a/docs/DOCS.html
+++ b/docs/DOCS.html
@@ -8,7 +8,7 @@
 <title>Cloud Pipelines Scripts</title>
 <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700">
 <style>
-/* Asciidoctor default stylesheet | MIT License | http://asciidoctor.org */
+/* Asciidoctor default stylesheet | MIT License | https://asciidoctor.org */
 /* Uncomment @import statement below to use as custom stylesheet */
 /*@import "https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700";*/
 article,aside,details,figcaption,figure,footer,header,hgroup,main,nav,section,summary{display:block}
@@ -975,7 +975,7 @@ microservices. That way, the testing setup looks like the following image:</p>
 </div>
 <div class="paragraph">
 <p>Such an approach to testing and deployment gives the following benefits
-(thanks to the usage of <a href="http://cloud.spring.io/spring-cloud-contract/spring-cloud-contract.html">Spring Cloud Contract</a>):</p>
+(thanks to the usage of <a href="https://cloud.spring.io/spring-cloud-contract/spring-cloud-contract.html">Spring Cloud Contract</a>):</p>
 </div>
 <div class="ulist">
 <ul>
@@ -986,7 +986,7 @@ microservices. That way, the testing setup looks like the following image:</p>
 <p>The stubs used for the tests run on a deployed microservice are the same as those used during integration tests.</p>
 </li>
 <li>
-<p>Those stubs have been tested against the application that produces them (see <a href="http://cloud.spring.io/spring-cloud-contract/spring-cloud-contract.html">Spring Cloud Contract</a> for more information).</p>
+<p>Those stubs have been tested against the application that produces them (see <a href="https://cloud.spring.io/spring-cloud-contract/spring-cloud-contract.html">Spring Cloud Contract</a> for more information).</p>
 </li>
 <li>
 <p>We do not have many slow tests running on a deployed application, so the pipeline gets executed much faster.</p>
@@ -2422,7 +2422,7 @@ contains no tests or documentation, it is extremely small and can be used in the
 <div class="sect2">
 <h3 id="building-prerequisites"><a class="link" href="#building-prerequisites">6.2. Prerequisites</a></h3>
 <div class="paragraph">
-<p>As prerequisites, you need to have <a href="http://www.shellcheck.net/">shellcheck</a>,
+<p>As prerequisites, you need to have <a href="https://www.shellcheck.net/">shellcheck</a>,
 <a href="https://github.com/sstephenson/bats">bats</a>, <a href="https://stedolan.github.io/jq/">jq</a>
 and <a href="https://rubyinstaller.org/downloads/">ruby</a> installed. If you use a Linux
 machine, <code>bats</code> and <code>shellcheck</code> are installed for you.</p>

--- a/docs/FLOW.html
+++ b/docs/FLOW.html
@@ -8,7 +8,7 @@
 <title>The Flow</title>
 <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700">
 <style>
-/* Asciidoctor default stylesheet | MIT License | http://asciidoctor.org */
+/* Asciidoctor default stylesheet | MIT License | https://asciidoctor.org */
 /* Uncomment @import statement below to use as custom stylesheet */
 /*@import "https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700";*/
 article,aside,details,figcaption,figure,footer,header,hgroup,main,nav,section,summary{display:block}
@@ -655,7 +655,7 @@ microservices. That way, the testing setup looks like the following image:</p>
 </div>
 <div class="paragraph">
 <p>Such an approach to testing and deployment gives the following benefits
-(thanks to the usage of <a href="http://cloud.spring.io/spring-cloud-contract/spring-cloud-contract.html">Spring Cloud Contract</a>):</p>
+(thanks to the usage of <a href="https://cloud.spring.io/spring-cloud-contract/spring-cloud-contract.html">Spring Cloud Contract</a>):</p>
 </div>
 <div class="ulist">
 <ul>
@@ -666,7 +666,7 @@ microservices. That way, the testing setup looks like the following image:</p>
 <p>The stubs used for the tests run on a deployed microservice are the same as those used during integration tests.</p>
 </li>
 <li>
-<p>Those stubs have been tested against the application that produces them (see <a href="http://cloud.spring.io/spring-cloud-contract/spring-cloud-contract.html">Spring Cloud Contract</a> for more information).</p>
+<p>Those stubs have been tested against the application that produces them (see <a href="https://cloud.spring.io/spring-cloud-contract/spring-cloud-contract.html">Spring Cloud Contract</a> for more information).</p>
 </li>
 <li>
 <p>We do not have many slow tests running on a deployed application, so the pipeline gets executed much faster.</p>

--- a/docs/INTRO.html
+++ b/docs/INTRO.html
@@ -8,7 +8,7 @@
 <title>Introduction</title>
 <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700">
 <style>
-/* Asciidoctor default stylesheet | MIT License | http://asciidoctor.org */
+/* Asciidoctor default stylesheet | MIT License | https://asciidoctor.org */
 /* Uncomment @import statement below to use as custom stylesheet */
 /*@import "https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700";*/
 article,aside,details,figcaption,figure,footer,header,hgroup,main,nav,section,summary{display:block}
@@ -913,7 +913,7 @@ microservices. That way, the testing setup looks like the following image:</p>
 </div>
 <div class="paragraph">
 <p>Such an approach to testing and deployment gives the following benefits
-(thanks to the usage of <a href="http://cloud.spring.io/spring-cloud-contract/spring-cloud-contract.html">Spring Cloud Contract</a>):</p>
+(thanks to the usage of <a href="https://cloud.spring.io/spring-cloud-contract/spring-cloud-contract.html">Spring Cloud Contract</a>):</p>
 </div>
 <div class="ulist">
 <ul>
@@ -924,7 +924,7 @@ microservices. That way, the testing setup looks like the following image:</p>
 <p>The stubs used for the tests run on a deployed microservice are the same as those used during integration tests.</p>
 </li>
 <li>
-<p>Those stubs have been tested against the application that produces them (see <a href="http://cloud.spring.io/spring-cloud-contract/spring-cloud-contract.html">Spring Cloud Contract</a> for more information).</p>
+<p>Those stubs have been tested against the application that produces them (see <a href="https://cloud.spring.io/spring-cloud-contract/spring-cloud-contract.html">Spring Cloud Contract</a> for more information).</p>
 </li>
 <li>
 <p>We do not have many slow tests running on a deployed application, so the pipeline gets executed much faster.</p>

--- a/docs/OPINIONATED.html
+++ b/docs/OPINIONATED.html
@@ -8,7 +8,7 @@
 <title>Opinionated Implementation</title>
 <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700">
 <style>
-/* Asciidoctor default stylesheet | MIT License | http://asciidoctor.org */
+/* Asciidoctor default stylesheet | MIT License | https://asciidoctor.org */
 /* Uncomment @import statement below to use as custom stylesheet */
 /*@import "https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700";*/
 article,aside,details,figcaption,figure,footer,header,hgroup,main,nav,section,summary{display:block}

--- a/docs/TECH.html
+++ b/docs/TECH.html
@@ -8,7 +8,7 @@
 <title>Building the Project</title>
 <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700">
 <style>
-/* Asciidoctor default stylesheet | MIT License | http://asciidoctor.org */
+/* Asciidoctor default stylesheet | MIT License | https://asciidoctor.org */
 /* Uncomment @import statement below to use as custom stylesheet */
 /*@import "https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700";*/
 article,aside,details,figcaption,figure,footer,header,hgroup,main,nav,section,summary{display:block}
@@ -504,7 +504,7 @@ contains no tests or documentation, it is extremely small and can be used in the
 <div class="sect2">
 <h3 id="building-prerequisites"><a class="link" href="#building-prerequisites">1.2. Prerequisites</a></h3>
 <div class="paragraph">
-<p>As prerequisites, you need to have <a href="http://www.shellcheck.net/">shellcheck</a>,
+<p>As prerequisites, you need to have <a href="https://www.shellcheck.net/">shellcheck</a>,
 <a href="https://github.com/sstephenson/bats">bats</a>, <a href="https://stedolan.github.io/jq/">jq</a>
 and <a href="https://rubyinstaller.org/downloads/">ruby</a> installed. If you use a Linux
 machine, <code>bats</code> and <code>shellcheck</code> are installed for you.</p>

--- a/docs/index.html
+++ b/docs/index.html
@@ -8,7 +8,7 @@
 <title>Cloud Pipelines Scripts</title>
 <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700">
 <style>
-/* Asciidoctor default stylesheet | MIT License | http://asciidoctor.org */
+/* Asciidoctor default stylesheet | MIT License | https://asciidoctor.org */
 /* Uncomment @import statement below to use as custom stylesheet */
 /*@import "https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700";*/
 article,aside,details,figcaption,figure,footer,header,hgroup,main,nav,section,summary{display:block}
@@ -975,7 +975,7 @@ microservices. That way, the testing setup looks like the following image:</p>
 </div>
 <div class="paragraph">
 <p>Such an approach to testing and deployment gives the following benefits
-(thanks to the usage of <a href="http://cloud.spring.io/spring-cloud-contract/spring-cloud-contract.html">Spring Cloud Contract</a>):</p>
+(thanks to the usage of <a href="https://cloud.spring.io/spring-cloud-contract/spring-cloud-contract.html">Spring Cloud Contract</a>):</p>
 </div>
 <div class="ulist">
 <ul>
@@ -986,7 +986,7 @@ microservices. That way, the testing setup looks like the following image:</p>
 <p>The stubs used for the tests run on a deployed microservice are the same as those used during integration tests.</p>
 </li>
 <li>
-<p>Those stubs have been tested against the application that produces them (see <a href="http://cloud.spring.io/spring-cloud-contract/spring-cloud-contract.html">Spring Cloud Contract</a> for more information).</p>
+<p>Those stubs have been tested against the application that produces them (see <a href="https://cloud.spring.io/spring-cloud-contract/spring-cloud-contract.html">Spring Cloud Contract</a> for more information).</p>
 </li>
 <li>
 <p>We do not have many slow tests running on a deployed application, so the pipeline gets executed much faster.</p>
@@ -2422,7 +2422,7 @@ contains no tests or documentation, it is extremely small and can be used in the
 <div class="sect2">
 <h3 id="building-prerequisites"><a class="link" href="#building-prerequisites">6.2. Prerequisites</a></h3>
 <div class="paragraph">
-<p>As prerequisites, you need to have <a href="http://www.shellcheck.net/">shellcheck</a>,
+<p>As prerequisites, you need to have <a href="https://www.shellcheck.net/">shellcheck</a>,
 <a href="https://github.com/sstephenson/bats">bats</a>, <a href="https://stedolan.github.io/jq/">jq</a>
 and <a href="https://rubyinstaller.org/downloads/">ruby</a> installed. If you use a Linux
 machine, <code>bats</code> and <code>shellcheck</code> are installed for you.</p>

--- a/src/test/bats/fixtures/ansible/ansible-inventory/prod
+++ b/src/test/bats/fixtures/ansible/ansible-inventory/prod
@@ -23,5 +23,5 @@ github-analytics_spring_datasource_url = jdbc:mysql://10.164.0.4:3306/test?autoR
 github-analytics_spring_datasource_username = root
 github-analytics_spring_datasource_password = root
 github-analytics_spring_rabbitmq_addresses = 10.164.0.4:5672
-github-analytics_eureka_client_serviceurl_defaultzone = http://10.164.0.4:8761/eureka/
+github-analytics_eureka_client_serviceurl_defaultzone = https://10.164.0.4:8761/eureka/
 github-webhook_port = 8082

--- a/src/test/bats/fixtures/generic/npm_repo/package.json
+++ b/src/test/bats/fixtures/generic/npm_repo/package.json
@@ -2,7 +2,7 @@
 	"name": "bookstore",
 	"version": "1.0.0",
 	"description": "Simple bookstore app",
-	"repository": "http://registry.npmjs.org/",
+	"repository": "https://registry.npmjs.org/",
 	"main": "app.js",
 	"scripts": {
 		"test": "./run_tests.sh"

--- a/src/test/bats/pipeline-ansible.bats
+++ b/src/test/bats/pipeline-ansible.bats
@@ -14,7 +14,7 @@ setup() {
 	export ENVIRONMENT="TEST"
 	export LANGUAGE_TYPE="dummy"
 	export PAAS_TYPE="ANSIBLE"
-	export REPO_WITH_BINARIES="http://foo"
+	export REPO_WITH_BINARIES="https://foo"
 	export ANSIBLE_INVENTORY_DIR="${FIXTURES_DIR}/ansible/ansible-inventory"
 	export SCRIPTS_DIR="${TEMP_DIR}"/scripts
 
@@ -133,8 +133,8 @@ teardown() {
 
 @test "should deploy for rollback tests [ansible]" {
 	export PROJECT_NAME="foo"
-	export APPLICATION_URL="http://foo/bar"
-	export STUBRUNNER_URL="http://bar/baz"
+	export APPLICATION_URL="https://foo/bar"
+	export STUBRUNNER_URL="https://bar/baz"
 	export PIPELINE_VERSION="1.0.0"
 	cd "${TEMP_DIR}/gradle"
 	source "${SCRIPTS_DIR}/pipeline.sh"

--- a/src/test/bats/pipeline-cf.bats
+++ b/src/test/bats/pipeline-cf.bats
@@ -12,7 +12,7 @@ setup() {
 
 	export ENVIRONMENT="TEST"
 	export PAAS_TYPE="CF"
-	export REPO_WITH_BINARIES="http://foo"
+	export REPO_WITH_BINARIES="https://foo"
 
 	export PAAS_TEST_USERNAME="test-username"
 	export PAAS_TEST_PASSWORD="test-password"
@@ -310,7 +310,7 @@ export -f fakeRetrieveStubRunnerIds
 	# Stub Runner
 	assert_output --partial "Setting env var [APPLICATION_HOSTNAME] -> [stubrunner-test-my-project] for app [stubrunner]"
 	assert_output --partial "Setting env var [APPLICATION_DOMAIN] -> [cfapps.io] for app [stubrunner]"
-	assert_output --partial "curl -u foo:bar http://foo/com/example/github/github-analytics-stub-runner-boot-classpath-stubs/0.0.1.M1/github-analytics-stub-runner-boot-classpath-stubs-0.0.1.M1.jar -o"
+	assert_output --partial "curl -u foo:bar https://foo/com/example/github/github-analytics-stub-runner-boot-classpath-stubs/0.0.1.M1/github-analytics-stub-runner-boot-classpath-stubs-0.0.1.M1.jar -o"
 	assert_output --partial "cf curl /v2/apps/4215794a-eeef-4de2-9a80-c73b5d1a02be -X PUT"
 	assert_output --partial "[8080,10000,10001,10002"
 	assert_output --partial "cf create-route test-space-my-project cfapps.io --hostname stubrunner-test-my-project-10000"
@@ -348,7 +348,7 @@ export -f fakeRetrieveStubRunnerIds
 	assert_output --partial "cf login -u ${env}-username -p ${env}-password -o ${env}-org -s ${env}-space-my-project"
 	refute_output --partial "No legacy pipeline descriptor [sc-pipelines.yml] found - will not deploy any services"
 	# App
-	assert_output --partial "curl -u foo:bar http://foo/com/example/my-project/1.0.0.M8/my-project-1.0.0.M8.tar.gz -o ${TEMP_DIR}/generic/php_repo/target/my-project-1.0.0.M8.tar.gz --fail"
+	assert_output --partial "curl -u foo:bar https://foo/com/example/my-project/1.0.0.M8/my-project-1.0.0.M8.tar.gz -o ${TEMP_DIR}/generic/php_repo/target/my-project-1.0.0.M8.tar.gz --fail"
 	assert_output --partial "tar -zxf ${TEMP_DIR}/generic/php_repo/target/my-project-1.0.0.M8.tar.gz -C target/source"
 	assert_output --partial "cf push my-project -f manifest.yml -p . -n my-project-test -i 1 --no-start"
 	assert_output --partial "cf set-env my-project SPRING_PROFILES_ACTIVE cloud,smoke,test"
@@ -408,7 +408,7 @@ export -f fakeRetrieveStubRunnerIds
 	# Stub Runner
 	assert_output --partial "Setting env var [APPLICATION_HOSTNAME] -> [stubrunner-test-${projectNameUppercase}] for app [stubrunner]"
 	assert_output --partial "Setting env var [APPLICATION_DOMAIN] -> [artifactId] for app [stubrunner]"
-	assert_output --partial "curl -u foo:bar http://foo/com/example/github/github-analytics-stub-runner-boot-classpath-stubs/0.0.1.M1/github-analytics-stub-runner-boot-classpath-stubs-0.0.1.M1.jar -o"
+	assert_output --partial "curl -u foo:bar https://foo/com/example/github/github-analytics-stub-runner-boot-classpath-stubs/0.0.1.M1/github-analytics-stub-runner-boot-classpath-stubs-0.0.1.M1.jar -o"
 	assert_output --partial "cf curl /v2/apps/4215794a-eeef-4de2-9a80-c73b5d1a02be -X PUT"
 	assert_output --partial "[8080,10000,10001,10002"
 	assert_output --partial "cf create-route test-space-${projectNameUppercase} artifactId --hostname stubrunner-test-${projectNameUppercase}-10000"

--- a/src/test/bats/pipeline-php.bats
+++ b/src/test/bats/pipeline-php.bats
@@ -59,7 +59,7 @@ function curl {
 	export PIPELINE_VERSION=1.0.0.M8
 	export M2_SETTINGS_REPO_USERNAME="foo"
 	export M2_SETTINGS_REPO_PASSWORD="bar"
-	export REPO_WITH_BINARIES_FOR_UPLOAD="http://foo"
+	export REPO_WITH_BINARIES_FOR_UPLOAD="https://foo"
 	source "${SOURCE_DIR}/projectType/pipeline-php.sh"
 
 	run build
@@ -67,7 +67,7 @@ function curl {
 	# App
 	assert_output --partial "composer install"
 	assert_output --partial "tar -czf"
-	assert_output --partial "curl -u foo:bar -X PUT http://foo/com/example/my-project/1.0.0.M8/my-project-1.0.0.M8.tar.gz --upload-file"
+	assert_output --partial "curl -u foo:bar -X PUT https://foo/com/example/my-project/1.0.0.M8/my-project-1.0.0.M8.tar.gz --upload-file"
 	# We don't want exception on jq parsing
 	refute_output --partial "Cannot iterate over null (null)"
 	assert_success


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* http://tarball.com (200) with 2 occurrences could not be migrated:  
   ([https](https://tarball.com) result AnnotatedConnectException).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* http://10.164.0.4:8761/eureka/ (ConnectTimeoutException) with 1 occurrences migrated to:  
  https://10.164.0.4:8761/eureka/ ([https](https://10.164.0.4:8761/eureka/) result ConnectTimeoutException).
* http://bar/baz (UnknownHostException) with 1 occurrences migrated to:  
  https://bar/baz ([https](https://bar/baz) result UnknownHostException).
* http://foo (UnknownHostException) with 3 occurrences migrated to:  
  https://foo ([https](https://foo) result UnknownHostException).
* http://foo/bar (UnknownHostException) with 1 occurrences migrated to:  
  https://foo/bar ([https](https://foo/bar) result UnknownHostException).
* http://foo/com/example/github/github-analytics-stub-runner-boot-classpath-stubs/0.0.1.M1/github-analytics-stub-runner-boot-classpath-stubs-0.0.1.M1.jar (UnknownHostException) with 2 occurrences migrated to:  
  https://foo/com/example/github/github-analytics-stub-runner-boot-classpath-stubs/0.0.1.M1/github-analytics-stub-runner-boot-classpath-stubs-0.0.1.M1.jar ([https](https://foo/com/example/github/github-analytics-stub-runner-boot-classpath-stubs/0.0.1.M1/github-analytics-stub-runner-boot-classpath-stubs-0.0.1.M1.jar) result UnknownHostException).
* http://foo/com/example/my-project/1.0.0.M8/my-project-1.0.0.M8.tar.gz (UnknownHostException) with 2 occurrences migrated to:  
  https://foo/com/example/my-project/1.0.0.M8/my-project-1.0.0.M8.tar.gz ([https](https://foo/com/example/my-project/1.0.0.M8/my-project-1.0.0.M8.tar.gz) result UnknownHostException).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://EditorConfig.org with 1 occurrences migrated to:  
  https://EditorConfig.org ([https](https://EditorConfig.org) result 200).
* http://asciidoctor.org with 8 occurrences migrated to:  
  https://asciidoctor.org ([https](https://asciidoctor.org) result 200).
* http://cloud.spring.io/spring-cloud-contract/spring-cloud-contract.html with 10 occurrences migrated to:  
  https://cloud.spring.io/spring-cloud-contract/spring-cloud-contract.html ([https](https://cloud.spring.io/spring-cloud-contract/spring-cloud-contract.html) result 200).
* http://registry.npmjs.org/ with 1 occurrences migrated to:  
  https://registry.npmjs.org/ ([https](https://registry.npmjs.org/) result 200).
* http://www.java.com/en/download/help/error_hotspot.xml with 1 occurrences migrated to:  
  https://www.java.com/en/download/help/error_hotspot.xml ([https](https://www.java.com/en/download/help/error_hotspot.xml) result 200).
* http://www.shellcheck.net/ with 4 occurrences migrated to:  
  https://www.shellcheck.net/ ([https](https://www.shellcheck.net/) result 200).

# Ignored
These URLs were intentionally ignored.

* http://localhost with 2 occurrences