### PR TITLE
URL Cleanup

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,4 +1,4 @@
-# EditorConfig is awesome: http://EditorConfig.org
+# EditorConfig is awesome: https://EditorConfig.org
 
 # top-most EditorConfig file
 root = true

--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@
 *.war
 *.ear
 
-# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
+# virtual machine crash logs, see https://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
 
 .gradle

--- a/docs-sources/src/main/asciidoc/INTRO.adoc
+++ b/docs-sources/src/main/asciidoc/INTRO.adoc
@@ -247,11 +247,11 @@ microservices. That way the testing setup looks like this:
 image::{intro-root-docs}/stubbed_dependencies.png[title="We're testing microservices in isolation"]
 
 Such an approach to testing and deployment gives the following benefits
-(thanks to the usage of http://cloud.spring.io/spring-cloud-contract/spring-cloud-contract.html[Spring Cloud Contract]):
+(thanks to the usage of https://cloud.spring.io/spring-cloud-contract/spring-cloud-contract.html[Spring Cloud Contract]):
 
 - No need to deploy dependant services
 - The stubs used for the tests ran on a deployed microservice are the same as those used during integration tests
-- Those stubs have been tested against the application that produces them (check http://cloud.spring.io/spring-cloud-contract/spring-cloud-contract.html[Spring Cloud Contract] for more information)
+- Those stubs have been tested against the application that produces them (check https://cloud.spring.io/spring-cloud-contract/spring-cloud-contract.html[Spring Cloud Contract] for more information)
 - We don't have many slow tests running on a deployed application - thus the pipeline gets executed much faster
 - We don't have to queue deployments - we're testing in isolation thus pipelines don't interfere with each other
 - We don't have to spawn virtual machines each time for deployment purposes

--- a/docs-sources/src/main/asciidoc/TECH.adoc
+++ b/docs-sources/src/main/asciidoc/TECH.adoc
@@ -14,7 +14,7 @@ In the `docs-source` folder you have the sources required to generate the docume
 
 === Prerequisites
 
-As prerequisites you need to have http://www.shellcheck.net/[shellcheck],
+As prerequisites you need to have https://www.shellcheck.net/[shellcheck],
 https://github.com/sstephenson/bats[bats], https://stedolan.github.io/jq/[jq]
  and https://rubyinstaller.org/downloads/[ruby] installed. If you're on a Linux
  machine then `bats` and `shellcheck` will be installed for you.

--- a/docs/CUSTOMIZATION.html
+++ b/docs/CUSTOMIZATION.html
@@ -8,7 +8,7 @@
 <title>Customizing the project</title>
 <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700">
 <style>
-/* Asciidoctor default stylesheet | MIT License | http://asciidoctor.org */
+/* Asciidoctor default stylesheet | MIT License | https://asciidoctor.org */
 /* Remove comment around @import statement below when using as a custom stylesheet */
 /*@import "https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700";*/
 article,aside,details,figcaption,figure,footer,header,hgroup,main,nav,section,summary{display:block}

--- a/docs/DOCS.html
+++ b/docs/DOCS.html
@@ -8,7 +8,7 @@
 <title>Cloud Pipelines scripts</title>
 <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700">
 <style>
-/* Asciidoctor default stylesheet | MIT License | http://asciidoctor.org */
+/* Asciidoctor default stylesheet | MIT License | https://asciidoctor.org */
 /* Remove comment around @import statement below when using as a custom stylesheet */
 /*@import "https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700";*/
 article,aside,details,figcaption,figure,footer,header,hgroup,main,nav,section,summary{display:block}
@@ -952,7 +952,7 @@ microservices. That way the testing setup looks like this:</p>
 </div>
 <div class="paragraph">
 <p>Such an approach to testing and deployment gives the following benefits
-(thanks to the usage of <a href="http://cloud.spring.io/spring-cloud-contract/spring-cloud-contract.html">Spring Cloud Contract</a>):</p>
+(thanks to the usage of <a href="https://cloud.spring.io/spring-cloud-contract/spring-cloud-contract.html">Spring Cloud Contract</a>):</p>
 </div>
 <div class="ulist">
 <ul>
@@ -963,7 +963,7 @@ microservices. That way the testing setup looks like this:</p>
 <p>The stubs used for the tests ran on a deployed microservice are the same as those used during integration tests</p>
 </li>
 <li>
-<p>Those stubs have been tested against the application that produces them (check <a href="http://cloud.spring.io/spring-cloud-contract/spring-cloud-contract.html">Spring Cloud Contract</a> for more information)</p>
+<p>Those stubs have been tested against the application that produces them (check <a href="https://cloud.spring.io/spring-cloud-contract/spring-cloud-contract.html">Spring Cloud Contract</a> for more information)</p>
 </li>
 <li>
 <p>We don&#8217;t have many slow tests running on a deployed application - thus the pipeline gets executed much faster</p>
@@ -2410,7 +2410,7 @@ contains no tests or documentation it&#8217;s extremely small and can be used in
 <div class="sect2">
 <h3 id="prerequisites">6.2. Prerequisites</h3>
 <div class="paragraph">
-<p>As prerequisites you need to have <a href="http://www.shellcheck.net/">shellcheck</a>,
+<p>As prerequisites you need to have <a href="https://www.shellcheck.net/">shellcheck</a>,
 <a href="https://github.com/sstephenson/bats">bats</a>, <a href="https://stedolan.github.io/jq/">jq</a>
  and <a href="https://rubyinstaller.org/downloads/">ruby</a> installed. If you&#8217;re on a Linux
  machine then <code>bats</code> and <code>shellcheck</code> will be installed for you.</p>

--- a/docs/INTRO.html
+++ b/docs/INTRO.html
@@ -8,7 +8,7 @@
 <title>Introduction</title>
 <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700">
 <style>
-/* Asciidoctor default stylesheet | MIT License | http://asciidoctor.org */
+/* Asciidoctor default stylesheet | MIT License | https://asciidoctor.org */
 /* Remove comment around @import statement below when using as a custom stylesheet */
 /*@import "https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700";*/
 article,aside,details,figcaption,figure,footer,header,hgroup,main,nav,section,summary{display:block}
@@ -894,7 +894,7 @@ microservices. That way the testing setup looks like this:</p>
 </div>
 <div class="paragraph">
 <p>Such an approach to testing and deployment gives the following benefits
-(thanks to the usage of <a href="http://cloud.spring.io/spring-cloud-contract/spring-cloud-contract.html">Spring Cloud Contract</a>):</p>
+(thanks to the usage of <a href="https://cloud.spring.io/spring-cloud-contract/spring-cloud-contract.html">Spring Cloud Contract</a>):</p>
 </div>
 <div class="ulist">
 <ul>
@@ -905,7 +905,7 @@ microservices. That way the testing setup looks like this:</p>
 <p>The stubs used for the tests ran on a deployed microservice are the same as those used during integration tests</p>
 </li>
 <li>
-<p>Those stubs have been tested against the application that produces them (check <a href="http://cloud.spring.io/spring-cloud-contract/spring-cloud-contract.html">Spring Cloud Contract</a> for more information)</p>
+<p>Those stubs have been tested against the application that produces them (check <a href="https://cloud.spring.io/spring-cloud-contract/spring-cloud-contract.html">Spring Cloud Contract</a> for more information)</p>
 </li>
 <li>
 <p>We don&#8217;t have many slow tests running on a deployed application - thus the pipeline gets executed much faster</p>

--- a/docs/OPINIONATED.html
+++ b/docs/OPINIONATED.html
@@ -8,7 +8,7 @@
 <title>Opinionated implementation</title>
 <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700">
 <style>
-/* Asciidoctor default stylesheet | MIT License | http://asciidoctor.org */
+/* Asciidoctor default stylesheet | MIT License | https://asciidoctor.org */
 /* Remove comment around @import statement below when using as a custom stylesheet */
 /*@import "https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700";*/
 article,aside,details,figcaption,figure,footer,header,hgroup,main,nav,section,summary{display:block}

--- a/docs/TECH.html
+++ b/docs/TECH.html
@@ -8,7 +8,7 @@
 <title>Building the project</title>
 <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700">
 <style>
-/* Asciidoctor default stylesheet | MIT License | http://asciidoctor.org */
+/* Asciidoctor default stylesheet | MIT License | https://asciidoctor.org */
 /* Remove comment around @import statement below when using as a custom stylesheet */
 /*@import "https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700";*/
 article,aside,details,figcaption,figure,footer,header,hgroup,main,nav,section,summary{display:block}
@@ -469,7 +469,7 @@ contains no tests or documentation it&#8217;s extremely small and can be used in
 <div class="sect2">
 <h3 id="prerequisites">1.2. Prerequisites</h3>
 <div class="paragraph">
-<p>As prerequisites you need to have <a href="http://www.shellcheck.net/">shellcheck</a>,
+<p>As prerequisites you need to have <a href="https://www.shellcheck.net/">shellcheck</a>,
 <a href="https://github.com/sstephenson/bats">bats</a>, <a href="https://stedolan.github.io/jq/">jq</a>
  and <a href="https://rubyinstaller.org/downloads/">ruby</a> installed. If you&#8217;re on a Linux
  machine then <code>bats</code> and <code>shellcheck</code> will be installed for you.</p>

--- a/docs/index.html
+++ b/docs/index.html
@@ -8,7 +8,7 @@
 <title>Cloud Pipelines scripts</title>
 <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700">
 <style>
-/* Asciidoctor default stylesheet | MIT License | http://asciidoctor.org */
+/* Asciidoctor default stylesheet | MIT License | https://asciidoctor.org */
 /* Remove comment around @import statement below when using as a custom stylesheet */
 /*@import "https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700";*/
 article,aside,details,figcaption,figure,footer,header,hgroup,main,nav,section,summary{display:block}
@@ -952,7 +952,7 @@ microservices. That way the testing setup looks like this:</p>
 </div>
 <div class="paragraph">
 <p>Such an approach to testing and deployment gives the following benefits
-(thanks to the usage of <a href="http://cloud.spring.io/spring-cloud-contract/spring-cloud-contract.html">Spring Cloud Contract</a>):</p>
+(thanks to the usage of <a href="https://cloud.spring.io/spring-cloud-contract/spring-cloud-contract.html">Spring Cloud Contract</a>):</p>
 </div>
 <div class="ulist">
 <ul>
@@ -963,7 +963,7 @@ microservices. That way the testing setup looks like this:</p>
 <p>The stubs used for the tests ran on a deployed microservice are the same as those used during integration tests</p>
 </li>
 <li>
-<p>Those stubs have been tested against the application that produces them (check <a href="http://cloud.spring.io/spring-cloud-contract/spring-cloud-contract.html">Spring Cloud Contract</a> for more information)</p>
+<p>Those stubs have been tested against the application that produces them (check <a href="https://cloud.spring.io/spring-cloud-contract/spring-cloud-contract.html">Spring Cloud Contract</a> for more information)</p>
 </li>
 <li>
 <p>We don&#8217;t have many slow tests running on a deployed application - thus the pipeline gets executed much faster</p>
@@ -2410,7 +2410,7 @@ contains no tests or documentation it&#8217;s extremely small and can be used in
 <div class="sect2">
 <h3 id="prerequisites">6.2. Prerequisites</h3>
 <div class="paragraph">
-<p>As prerequisites you need to have <a href="http://www.shellcheck.net/">shellcheck</a>,
+<p>As prerequisites you need to have <a href="https://www.shellcheck.net/">shellcheck</a>,
 <a href="https://github.com/sstephenson/bats">bats</a>, <a href="https://stedolan.github.io/jq/">jq</a>
  and <a href="https://rubyinstaller.org/downloads/">ruby</a> installed. If you&#8217;re on a Linux
  machine then <code>bats</code> and <code>shellcheck</code> will be installed for you.</p>

--- a/src/main/bash/ansible/deploy-jvm-service.yml
+++ b/src/main/bash/ansible/deploy-jvm-service.yml
@@ -6,7 +6,7 @@
   vars:
     maven_repository_url: "{{ lookup('env', 'REPO_WITH_BINARIES') }}"
     app_port: "{{ hostvars[inventory_hostname][app_name + '_port'] }}"
-    app_healt_url: "http://localhost:{{ app_port }}/health"
+    app_healt_url: "https://localhost:{{ app_port }}/health"
   tasks:
     - name: ensure required arguments were passed
       assert:

--- a/src/main/bash/ansible/deploy-stubrunner.yml
+++ b/src/main/bash/ansible/deploy-stubrunner.yml
@@ -8,7 +8,7 @@
     maven_repository_url: "{{ lookup('env', 'REPO_WITH_BINARIES') }}"
     stubrunner_ids: ""
     stubrunner_port: "{{ hostvars[inventory_hostname][app_name + '_stubrunner_port'] }}"
-    stubrunner_healt_url: "http://localhost:{{ stubrunner_port }}/health"
+    stubrunner_healt_url: "https://localhost:{{ stubrunner_port }}/health"
   tasks:
     - name: read pipeline descriptor
       include_vars:

--- a/src/test/bats/docs_helper/zshelldoc/LICENSE
+++ b/src/test/bats/docs_helper/zshelldoc/LICENSE
@@ -27,7 +27,7 @@ GPLv3  License
                     GNU GENERAL PUBLIC LICENSE
                        Version 3, 29 June 2007
 
- Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
  Everyone is permitted to copy and distribute verbatim copies
  of this license document, but changing it is not allowed.
 
@@ -671,7 +671,7 @@ the "copyright" line and a pointer to where the full notice is found.
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 Also add information on how to contact you by electronic and paper mail.
 
@@ -690,11 +690,11 @@ might be different; for a GUI interface, you would use an "about box".
   You should also get your employer (if you work as a programmer) or school,
 if any, to sign a "copyright disclaimer" for the program, if necessary.
 For more information on this, and how to apply and follow the GNU GPL, see
-<http://www.gnu.org/licenses/>.
+<https://www.gnu.org/licenses/>.
 
   The GNU General Public License does not permit incorporating your program
 into proprietary programs.  If your program is a subroutine library, you
 may consider it more useful to permit linking proprietary applications with
 the library.  If this is what you want to do, use the GNU Lesser General
 Public License instead of this License.  But first, please read
-<http://www.gnu.org/philosophy/why-not-lgpl.html>.
+<https://www.gnu.org/philosophy/why-not-lgpl.html>.

--- a/src/test/bats/docs_helper/zshelldoc/README.md
+++ b/src/test/bats/docs_helper/zshelldoc/README.md
@@ -103,7 +103,7 @@ Few rules helping to use `Zshelldoc` in your project:
  1. Be aware that to convert a group of scripts, you simply need `zsd file1.zsh file2.zsh ...` – cross-file function invocations will work automatically, and multiple `*.adoc` files will be created.
  1. Create `Makefile` with `doc` target, that does `rm -rf zsdoc/data; zsd -v file1.zsh ...`. Documentation will land in `zsdoc` directory.
  1. Directory `zsdoc/data` holds meta-data used to create `asciidoc` documents (`*.adoc` files). You can remove it or analyze it yourself.
- 1. Obtain **PDFs** with [Asciidoctor](http://asciidoctor.org/) tool via: `asciidoctor -b pdf -r asciidoctor-pdf file1.zsh.adoc`. Install `Asciidoctor` with: `gem install asciidoctor-pdf --pre`. (Check out [Zplugin's Makefile](https://github.com/zdharma/zplugin/blob/master/zsdoc/Makefile).)
+ 1. Obtain **PDFs** with [Asciidoctor](https://asciidoctor.org/) tool via: `asciidoctor -b pdf -r asciidoctor-pdf file1.zsh.adoc`. Install `Asciidoctor` with: `gem install asciidoctor-pdf --pre`. (Check out [Zplugin's Makefile](https://github.com/zdharma/zplugin/blob/master/zsdoc/Makefile).)
  1. HTML: `asciidoctor script.adoc`.
  1. Obtain manual pages with `Asciidoc` package via: `a2x -L --doctype manpage --format manpage file1.zsh.adoc` (`asciidoc` is a common package; its `a2x` command is little slow).
  1. Github supports `Asciidoc` documents and renders them automatically.

--- a/src/test/bats/docs_helper/zshelldoc/examples/.inputs/zsh-syntax-highlighting.zsh
+++ b/src/test/bats/docs_helper/zshelldoc/examples/.inputs/zsh-syntax-highlighting.zsh
@@ -56,7 +56,7 @@ fi
 # -------------------------------------------------------------------------------------------------
 
 # Use workaround for bug in ZSH?
-# zsh-users/zsh@48cadf4 http://www.zsh.org/mla/workers//2017/msg00034.html
+# zsh-users/zsh@48cadf4 https://www.zsh.org/mla/workers//2017/msg00034.html
 autoload -U is-at-least
 if is-at-least 5.3.2; then
   zsh_highlight__pat_static_bug=false

--- a/src/test/bats/docs_helper/zshelldoc/test/real-zsyh.zsh
+++ b/src/test/bats/docs_helper/zshelldoc/test/real-zsyh.zsh
@@ -56,7 +56,7 @@ fi
 # -------------------------------------------------------------------------------------------------
 
 # Use workaround for bug in ZSH?
-# zsh-users/zsh@48cadf4 http://www.zsh.org/mla/workers//2017/msg00034.html
+# zsh-users/zsh@48cadf4 https://www.zsh.org/mla/workers//2017/msg00034.html
 autoload -U is-at-least
 if is-at-least 5.3.2; then
   zsh_highlight__pat_static_bug=false

--- a/src/test/bats/docs_helper/zshelldoc/test/real-zsyh/data/bodies/real-zsyh.zsh.comments
+++ b/src/test/bats/docs_helper/zshelldoc/test/real-zsyh/data/bodies/real-zsyh.zsh.comments
@@ -46,7 +46,7 @@
 # -------------------------------------------------------------------------------------------------
 
 # Use workaround for bug in ZSH?
-# zsh-users/zsh@48cadf4 http://www.zsh.org/mla/workers//2017/msg00034.html
+# zsh-users/zsh@48cadf4 https://www.zsh.org/mla/workers//2017/msg00034.html
 
 # Array declaring active highlighters names.
 

--- a/src/test/bats/docs_helper/zshelldoc/test/real-zsyh/data/extended/real-zsyh.zsh
+++ b/src/test/bats/docs_helper/zshelldoc/test/real-zsyh/data/extended/real-zsyh.zsh
@@ -56,7 +56,7 @@ fi
 # -------------------------------------------------------------------------------------------------
 
 # Use workaround for bug in ZSH?
-# zsh-users/zsh@48cadf4 http://www.zsh.org/mla/workers//2017/msg00034.html
+# zsh-users/zsh@48cadf4 https://www.zsh.org/mla/workers//2017/msg00034.html
 autoload -U is-at-least
 if is-at-least 5.3.2; then
   zsh_highlight__pat_static_bug=false

--- a/src/test/bats/fixtures/generic/npm_repo/package.json
+++ b/src/test/bats/fixtures/generic/npm_repo/package.json
@@ -2,7 +2,7 @@
 	"name": "bookstore",
 	"version": "1.0.0",
 	"description": "Simple bookstore app",
-	"repository": "http://registry.npmjs.org/",
+	"repository": "https://registry.npmjs.org/",
 	"main": "app.js",
 	"scripts": {
 		"test": "./run_tests.sh"

--- a/src/test/bats/pipeline-cf.bats
+++ b/src/test/bats/pipeline-cf.bats
@@ -12,7 +12,7 @@ setup() {
 
 	export ENVIRONMENT="TEST"
 	export PAAS_TYPE="CF"
-	export REPO_WITH_BINARIES="http://foo"
+	export REPO_WITH_BINARIES="https://foo"
 
 	export PAAS_TEST_USERNAME="test-username"
 	export PAAS_TEST_PASSWORD="test-password"
@@ -310,7 +310,7 @@ export -f fakeRetrieveStubRunnerIds
 	# Stub Runner
 	assert_output --partial "Setting env var [APPLICATION_HOSTNAME] -> [stubrunner-test-my-project] for app [stubrunner]"
 	assert_output --partial "Setting env var [APPLICATION_DOMAIN] -> [cfapps.io] for app [stubrunner]"
-	assert_output --partial "curl -u foo:bar http://foo/com/example/github/github-analytics-stub-runner-boot-classpath-stubs/0.0.1.M1/github-analytics-stub-runner-boot-classpath-stubs-0.0.1.M1.jar -o"
+	assert_output --partial "curl -u foo:bar https://foo/com/example/github/github-analytics-stub-runner-boot-classpath-stubs/0.0.1.M1/github-analytics-stub-runner-boot-classpath-stubs-0.0.1.M1.jar -o"
 	assert_output --partial "cf curl /v2/apps/4215794a-eeef-4de2-9a80-c73b5d1a02be -X PUT"
 	assert_output --partial "[8080,10000,10001,10002"
 	assert_output --partial "cf create-route test-space-my-project cfapps.io --hostname stubrunner-test-my-project-10000"
@@ -348,7 +348,7 @@ export -f fakeRetrieveStubRunnerIds
 	assert_output --partial "cf login -u ${env}-username -p ${env}-password -o ${env}-org -s ${env}-space-my-project"
 	refute_output --partial "No legacy pipeline descriptor [sc-pipelines.yml] found - will not deploy any services"
 	# App
-	assert_output --partial "curl -u foo:bar http://foo/com/example/my-project/1.0.0.M8/my-project-1.0.0.M8.tar.gz -o ${TEMP_DIR}/generic/php_repo/target/my-project-1.0.0.M8.tar.gz --fail"
+	assert_output --partial "curl -u foo:bar https://foo/com/example/my-project/1.0.0.M8/my-project-1.0.0.M8.tar.gz -o ${TEMP_DIR}/generic/php_repo/target/my-project-1.0.0.M8.tar.gz --fail"
 	assert_output --partial "tar -zxf ${TEMP_DIR}/generic/php_repo/target/my-project-1.0.0.M8.tar.gz -C target/source"
 	assert_output --partial "cf push my-project -f manifest.yml -p . -n my-project-test -i 1 --no-start"
 	assert_output --partial "cf set-env my-project SPRING_PROFILES_ACTIVE cloud,smoke,test"
@@ -408,7 +408,7 @@ export -f fakeRetrieveStubRunnerIds
 	# Stub Runner
 	assert_output --partial "Setting env var [APPLICATION_HOSTNAME] -> [stubrunner-test-${projectNameUppercase}] for app [stubrunner]"
 	assert_output --partial "Setting env var [APPLICATION_DOMAIN] -> [artifactId] for app [stubrunner]"
-	assert_output --partial "curl -u foo:bar http://foo/com/example/github/github-analytics-stub-runner-boot-classpath-stubs/0.0.1.M1/github-analytics-stub-runner-boot-classpath-stubs-0.0.1.M1.jar -o"
+	assert_output --partial "curl -u foo:bar https://foo/com/example/github/github-analytics-stub-runner-boot-classpath-stubs/0.0.1.M1/github-analytics-stub-runner-boot-classpath-stubs-0.0.1.M1.jar -o"
 	assert_output --partial "cf curl /v2/apps/4215794a-eeef-4de2-9a80-c73b5d1a02be -X PUT"
 	assert_output --partial "[8080,10000,10001,10002"
 	assert_output --partial "cf create-route test-space-${projectNameUppercase} artifactId --hostname stubrunner-test-${projectNameUppercase}-10000"

--- a/src/test/bats/pipeline-php.bats
+++ b/src/test/bats/pipeline-php.bats
@@ -59,7 +59,7 @@ function curl {
 	export PIPELINE_VERSION=1.0.0.M8
 	export M2_SETTINGS_REPO_USERNAME="foo"
 	export M2_SETTINGS_REPO_PASSWORD="bar"
-	export REPO_WITH_BINARIES_FOR_UPLOAD="http://foo"
+	export REPO_WITH_BINARIES_FOR_UPLOAD="https://foo"
 	source "${SOURCE_DIR}/projectType/pipeline-php.sh"
 
 	run build
@@ -67,7 +67,7 @@ function curl {
 	# App
 	assert_output --partial "composer install"
 	assert_output --partial "tar -czf"
-	assert_output --partial "curl -u foo:bar -X PUT http://foo/com/example/my-project/1.0.0.M8/my-project-1.0.0.M8.tar.gz --upload-file"
+	assert_output --partial "curl -u foo:bar -X PUT https://foo/com/example/my-project/1.0.0.M8/my-project-1.0.0.M8.tar.gz --upload-file"
 	# We don't want exception on jq parsing
 	refute_output --partial "Cannot iterate over null (null)"
 	assert_success


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* [ ] http://mama.indstate.edu/users/ice/tree/ (200) with 1 occurrences could not be migrated:  
   ([https](https://mama.indstate.edu/users/ice/tree/) result AnnotatedConnectException).
* [ ] http://zsh.sourceforge.net/Doc/Release/Zsh-Line-Editor.html (200) with 1 occurrences could not be migrated:  
   ([https](https://zsh.sourceforge.net/Doc/Release/Zsh-Line-Editor.html) result AnnotatedConnectException).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://localhost (AnnotatedConnectException) with 2 occurrences migrated to:  
  https://localhost ([https](https://localhost) result AnnotatedConnectException).
* [ ] http://foo (UnknownHostException) with 2 occurrences migrated to:  
  https://foo ([https](https://foo) result UnknownHostException).
* [ ] http://foo/com/example/github/github-analytics-stub-runner-boot-classpath-stubs/0.0.1.M1/github-analytics-stub-runner-boot-classpath-stubs-0.0.1.M1.jar (UnknownHostException) with 2 occurrences migrated to:  
  https://foo/com/example/github/github-analytics-stub-runner-boot-classpath-stubs/0.0.1.M1/github-analytics-stub-runner-boot-classpath-stubs-0.0.1.M1.jar ([https](https://foo/com/example/github/github-analytics-stub-runner-boot-classpath-stubs/0.0.1.M1/github-analytics-stub-runner-boot-classpath-stubs-0.0.1.M1.jar) result UnknownHostException).
* [ ] http://foo/com/example/my-project/1.0.0.M8/my-project-1.0.0.M8.tar.gz (UnknownHostException) with 2 occurrences migrated to:  
  https://foo/com/example/my-project/1.0.0.M8/my-project-1.0.0.M8.tar.gz ([https](https://foo/com/example/my-project/1.0.0.M8/my-project-1.0.0.M8.tar.gz) result UnknownHostException).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://EditorConfig.org with 1 occurrences migrated to:  
  https://EditorConfig.org ([https](https://EditorConfig.org) result 200).
* [ ] http://asciidoctor.org with 6 occurrences migrated to:  
  https://asciidoctor.org ([https](https://asciidoctor.org) result 200).
* [ ] http://asciidoctor.org/ with 1 occurrences migrated to:  
  https://asciidoctor.org/ ([https](https://asciidoctor.org/) result 200).
* [ ] http://cloud.spring.io/spring-cloud-contract/spring-cloud-contract.html with 8 occurrences migrated to:  
  https://cloud.spring.io/spring-cloud-contract/spring-cloud-contract.html ([https](https://cloud.spring.io/spring-cloud-contract/spring-cloud-contract.html) result 200).
* [ ] http://registry.npmjs.org/ with 1 occurrences migrated to:  
  https://registry.npmjs.org/ ([https](https://registry.npmjs.org/) result 200).
* [ ] http://www.gnu.org/licenses/ with 2 occurrences migrated to:  
  https://www.gnu.org/licenses/ ([https](https://www.gnu.org/licenses/) result 200).
* [ ] http://www.gnu.org/philosophy/why-not-lgpl.html with 1 occurrences migrated to:  
  https://www.gnu.org/philosophy/why-not-lgpl.html ([https](https://www.gnu.org/philosophy/why-not-lgpl.html) result 200).
* [ ] http://www.java.com/en/download/help/error_hotspot.xml with 1 occurrences migrated to:  
  https://www.java.com/en/download/help/error_hotspot.xml ([https](https://www.java.com/en/download/help/error_hotspot.xml) result 200).
* [ ] http://www.shellcheck.net/ with 4 occurrences migrated to:  
  https://www.shellcheck.net/ ([https](https://www.shellcheck.net/) result 200).
* [ ] http://www.zsh.org/mla/workers//2017/msg00034.html with 4 occurrences migrated to:  
  https://www.zsh.org/mla/workers//2017/msg00034.html ([https](https://www.zsh.org/mla/workers//2017/msg00034.html) result 200).
* [ ] http://fsf.org/ with 1 occurrences migrated to:  
  https://fsf.org/ ([https](https://fsf.org/) result 301).